### PR TITLE
fix: GH15 Prevent direct access to gui

### DIFF
--- a/lib/opcache-gui/.htaccess
+++ b/lib/opcache-gui/.htaccess
@@ -1,0 +1,3 @@
+<Files "index.php.inc">
+    Require all denied
+</Files>


### PR DESCRIPTION
Fixes GH #15 Prevents direct access to index.php.inc either to read the file in plain text or, if the server is configured to render .inc files as PHP, the GUI